### PR TITLE
Develop

### DIFF
--- a/app/(root)/upload/page.tsx
+++ b/app/(root)/upload/page.tsx
@@ -2,12 +2,29 @@
 import FileInput from '@/components/file-input'
 import FormField from '@/components/form-field'
 import { MAX_THUMBNAIL_SIZE, MAX_VIDEO_SIZE } from '@/constants'
+import { getThumbnailUploadUrl, getVideoUploadUrl, saveVideoDetails } from '@/lib/actions/video'
 import { useFileInput } from '@/lib/hooks/useFileInput'
-import { ChangeEvent, FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react'
+
+const uploadFileToBunny = (file: File, uploadUrl: string, accessKey: string): Promise<void> => {
+    return fetch(uploadUrl, {
+        method: "PUT",
+        headers: {
+            "AccessKey": accessKey,
+            "Content-Type": file.type
+        },
+        body: file
+    }).then((response) => {
+        if (!response.ok) throw new Error("Failed to upload file");
+    })
+}
 
 const UploadPage = () => {
+    const router = useRouter();
     const [isSubmitting, setIsSubmitting] = useState(false)
-    const [formData, setFormData] = useState({
+    const [videoDuration, setVideoDuration] = useState(0)
+    const [formData, setFormData] = useState<{ title: string, description: string, visibility: Visibility }>({
         title: "",
         description: "",
         visibility: "public"
@@ -15,6 +32,13 @@ const UploadPage = () => {
 
     const video = useFileInput(MAX_VIDEO_SIZE);
     const thumbnail = useFileInput(MAX_THUMBNAIL_SIZE);
+
+    useEffect(() => {
+        if (video.duration !== null || 0) {
+            setVideoDuration(video.duration ?? 0);
+        }
+    }, [video.duration])
+
 
     const [error, setError] = useState<string>("")
 
@@ -30,19 +54,47 @@ const UploadPage = () => {
         setIsSubmitting(true);
 
         try {
-            if(!video.file || !thumbnail.file) {
+            if (!video.file || !thumbnail.file) {
                 setError("Please upload both video and thumbnail files.");
                 return;
             }
 
-            if(!formData.title || !formData.description) {
+            if (!formData.title || !formData.description) {
                 setError("Please fill in all the details.");
             }
 
-            //upload the video to Bunny
+            //get upload the video to Bunny url
+            const {
+                videoId,
+                uploadUrl: videoUploadUrl,
+                accessKey: videoAccessKey
+            } = await getVideoUploadUrl();
+
+            if (!videoUploadUrl || !videoAccessKey) {
+                throw new Error("Failed to get video upload credentials");
+            }
             //Upload the thumbnail to DB
+            await uploadFileToBunny(video.file, videoUploadUrl, videoAccessKey);
             //Atatch the thumbnail
+            const {
+                uploadUrl: thumbnailUploadUrl,
+                accessKey: thumbnailAccessKey,
+                cdnUrl: thumbnailCdnUrl
+            } = await getThumbnailUploadUrl(videoId as string);
+
+            if (!thumbnailUploadUrl || !thumbnailAccessKey || !thumbnailCdnUrl) throw new Error("Failed to get thumbnail upload credentials");
+
+            await uploadFileToBunny(thumbnail.file, thumbnailUploadUrl, thumbnailAccessKey);
+
             //Create a new DB entry fot the video details (urls, data)
+            await saveVideoDetails({
+                videoId,
+                thumbnailUrl: thumbnailCdnUrl,
+                ...formData,
+                duration: videoDuration,
+            })
+
+            router.push(`/video/${videoId}`);
         } catch (error) {
             console.error("Error submitting form: ", error);
         } finally {

--- a/app/(root)/upload/page.tsx
+++ b/app/(root)/upload/page.tsx
@@ -94,7 +94,7 @@ const UploadPage = () => {
                 duration: videoDuration,
             })
 
-            router.push(`/video/${videoId}`);
+            router.push(`/videos/${videoId}`);
         } catch (error) {
             console.error("Error submitting form: ", error);
         } finally {

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -3,7 +3,7 @@ export const MAX_THUMBNAIL_SIZE = 10 * 1024 * 1024;
 
 export const BUNNY = {
   STREAM_BASE_URL: "https://video.bunnycdn.com/library",
-  STORAGE_BASE_URL: "https://sg.storage.bunnycdn.com/ghost-snapcast",
+  STORAGE_BASE_URL: "https://storage.bunnycdn.com/ghost-snapcast",
   CDN_URL: "https://ghost-snapcast.b-cdn.net",
   EMBED_URL: "https://iframe.mediadelivery.net/embed",
   TRANSCRIPT_URL: "https://vz-689720fa-9a6.b-cdn.net",

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean, uuid, integer } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
     id: text('id').primaryKey(),
@@ -46,9 +46,27 @@ export const verification = pgTable("verification", {
     updatedAt: timestamp('updated_at').$defaultFn(() => /* @__PURE__ */ new Date())
 });
 
+export const videos = pgTable("videos", {
+  id: uuid("id").primaryKey().defaultRandom().unique(),
+  title: text("title").notNull(),
+  description: text("description").notNull(),
+  videoUrl: text("video_url").notNull(),
+  videoId: text("video_id").notNull(),
+  thumbnailUrl: text("thumbnail_url").notNull(),
+  visibility: text("visibility").$type<"public" | "private">().notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  views: integer("views").notNull().default(0),
+  duration: integer("duration"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
 export const schema = {
     user,
     session,
     account,
-    verification
+    verification,
+    videos
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,7 @@ declare interface VideoDetails {
   title: string;
   description: string;
   thumbnailUrl: string;
-  tags: string | string[];
+  //tags: string | string[];
   visibility: Visibility;
   duration?: number | null;
 }

--- a/lib/actions/video.ts
+++ b/lib/actions/video.ts
@@ -4,6 +4,7 @@ import { apiFetch, getEnv, withErrorHandling } from "@/lib/utils";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { BUNNY } from "@/constants";
+import { db } from "@/drizzle/db";
 
 const VIDEO_STREAM_BASE_URL = BUNNY.STREAM_BASE_URL;
 const THUMBNAIL_STORAGE_BASE_URL = BUNNY.STORAGE_BASE_URL;
@@ -61,4 +62,23 @@ export const getThumbnailUploadUrl = withErrorHandling(async (videoId : string) 
         cdnUrl,
         accessKey  :ACCESS_KEYS.storageAccessKey
     }
+})
+
+export const saveVideoDetails = withErrorHandling(async (videoDetails : VideoDetails)=> {
+    const userId = await getSessionUserId();
+
+    await apiFetch(
+        `${VIDEO_STREAM_BASE_URL}/${BUNNY_LIBRARY_ID}/videos/${videoDetails.videoId}`,
+        {
+            method : "POST",
+            bunnyType : "stream",
+            body : {
+                title : videoDetails.title,
+                description : videoDetails.description,
+
+            }
+        }
+    );
+
+    //await db.insert(videos).values({});
 })

--- a/lib/actions/video.ts
+++ b/lib/actions/video.ts
@@ -11,8 +11,8 @@ const THUMBNAIL_CDN_URL = BUNNY.CDN_URL;
 const BUNNY_LIBRARY_ID = getEnv("BUNNY_LIBRARY_ID");
 
 const ACCESS_KEYS = {
-    streamAccessKey = getEnv("BUNNY_STREAM_ACCESS_KEY"),
-    storageAccessKey = getEnv("BUNNY_STORAGE_ACCESS_KEY"),
+    streamAccessKey : getEnv("BUNNY_STREAM_ACCESS_KEY"),
+    storageAccessKey : getEnv("BUNNY_STORAGE_ACCESS_KEY"),
 };
 
 // Helper Functions
@@ -50,5 +50,15 @@ export const getVideoUploadUrl = withErrorHandling(async () => {
 })
 
 export const getThumbnailUploadUrl = withErrorHandling(async (videoId : string) => {
+    const fileName = `${Date.now()}-${videoId}-thumbnail`;
 
+    const uploadUrl = `${THUMBNAIL_STORAGE_BASE_URL}/thumbnails/${fileName}`;
+
+    const cdnUrl = `${THUMBNAIL_CDN_URL}/thumbnails/${fileName}`;
+
+    return {
+        uploadUrl,
+        cdnUrl,
+        accessKey  :ACCESS_KEYS.storageAccessKey
+    }
 })

--- a/lib/actions/video.ts
+++ b/lib/actions/video.ts
@@ -5,6 +5,7 @@ import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { BUNNY } from "@/constants";
 import { db } from "@/drizzle/db";
+import { videos } from "@/drizzle/schema";
 
 const VIDEO_STREAM_BASE_URL = BUNNY.STREAM_BASE_URL;
 const THUMBNAIL_STORAGE_BASE_URL = BUNNY.STORAGE_BASE_URL;
@@ -80,5 +81,11 @@ export const saveVideoDetails = withErrorHandling(async (videoDetails : VideoDet
         }
     );
 
-    //await db.insert(videos).values({});
+    await db.insert(videos).values({
+        ...videoDetails,
+        videoUrl : `${BUNNY.EMBED_URL}/${BUNNY_LIBRARY_ID}/${videoDetails.videoId}`,
+        userId,
+        createdAt : new Date(),
+        updatedAt : new Date()
+    });
 })

--- a/lib/actions/video.ts
+++ b/lib/actions/video.ts
@@ -66,7 +66,7 @@ export const getThumbnailUploadUrl = withErrorHandling(async (videoId : string) 
     return {
         uploadUrl,
         cdnUrl,
-        accessKey  :ACCESS_KEYS.storageAccessKey
+        accessKey : ACCESS_KEYS.storageAccessKey
     }
 })
 

--- a/lib/actions/video.ts
+++ b/lib/actions/video.ts
@@ -6,6 +6,7 @@ import { headers } from "next/headers";
 import { BUNNY } from "@/constants";
 import { db } from "@/drizzle/db";
 import { videos } from "@/drizzle/schema";
+import { revalidatePath } from "next/cache";
 
 const VIDEO_STREAM_BASE_URL = BUNNY.STREAM_BASE_URL;
 const THUMBNAIL_STORAGE_BASE_URL = BUNNY.STORAGE_BASE_URL;
@@ -24,6 +25,10 @@ const getSessionUserId = async () : Promise<string> => {
     if(!session) throw new Error("Unauthenticated");
 
     return session.user.id;
+}
+
+const revalidatePaths = (paths : string[]) => {
+    paths.forEach((path) => revalidatePath(path));
 }
 
 // Server Actions
@@ -88,4 +93,8 @@ export const saveVideoDetails = withErrorHandling(async (videoDetails : VideoDet
         createdAt : new Date(),
         updatedAt : new Date()
     });
+
+    revalidatePaths(["/"]);
+
+    return { videoId : videoDetails.videoId }
 })

--- a/lib/actions/video.ts
+++ b/lib/actions/video.ts
@@ -35,7 +35,7 @@ const revalidatePaths = (paths : string[]) => {
 export const getVideoUploadUrl = withErrorHandling(async () => {
     await getSessionUserId();
 
-    const videoResponse = await apiFetch(
+    const videoResponse = await apiFetch<BunnyVideoResponse>(
         `${VIDEO_STREAM_BASE_URL}/${BUNNY_LIBRARY_ID}/videos`,
         {
             method : "POST",


### PR DESCRIPTION
## Summary by Sourcery

Implement end-to-end video and thumbnail upload flow using Bunny CDN with server actions and Drizzle ORM, store metadata in a new "videos" table, and revalidate the home page after upload.

New Features:
- Add client-side flow to upload videos and thumbnails to Bunny CDN and save metadata via server actions
- Introduce server actions getVideoUploadUrl, getThumbnailUploadUrl, and saveVideoDetails for managing streaming and storage operations
- Create a new "videos" table schema with fields for metadata, relations, and timestamps using Drizzle ORM

Enhancements:
- Add a reusable helper for PUT uploads to Bunny storage and handle video duration extraction
- Use Next.js router for post-upload navigation to the video page
- Revalidate the home page cache after saving new video details

Chores:
- Update Bunny storage base URL constant
- Comment out unused tags property in VideoDetails type